### PR TITLE
feat(agenda): agregar endpoint dedicado para crear primera reunión de…

### DIFF
--- a/app/routers/agenda_router.py
+++ b/app/routers/agenda_router.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, HTTPException, status, Request, Query
 
 from app.services.AuthService import AuthService
 from app.services.AgendaService import AgendaService
-from app.schemas.Agenda import AgendaCreate, AgendaOut, AgendaUpdate
+from app.schemas.Agenda import AgendaCreate, AgendaOut, AgendaUpdate, FirstMeetingIn
 
 UNAUTHORIZED_MSG = "Usuario no autenticado. Debe iniciar sesión para poder visualizar este recurso."
 
@@ -80,3 +80,17 @@ def delete_event(agenda_id: int, request: Request):
     if not ok:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No se encontró el evento o no tiene permisos.")
     return {"deleted": True, "id": agenda_id}
+
+
+
+@router.post("/{case_id}/first-meeting", status_code=status.HTTP_201_CREATED, response_model=AgendaOut,
+             description="Crea la primera reunión del caso (título/descripcion automáticos)")
+def create_first_meeting(case_id: int, payload: FirstMeetingIn, request: Request):
+    jwt = request.cookies.get("accessToken")
+    user = AuthService.get_active_user(jwt)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=UNAUTHORIZED_MSG)
+
+    return AgendaService.create_first_meeting(
+    case_id=case_id, meeting_date=payload.meeting_date, user=user
+)

--- a/app/schemas/Agenda.py
+++ b/app/schemas/Agenda.py
@@ -2,6 +2,8 @@
 from datetime import datetime
 from typing import List, Optional
 from pydantic import BaseModel, Field, ConfigDict
+from datetime import date
+
 
 class AgendaCreate(BaseModel):
     event_name: str = Field(..., min_length=1, max_length=40)
@@ -25,3 +27,6 @@ class AgendaUpdate(BaseModel):
     description: Optional[str] = Field(None, min_length=1)
     due_date: Optional[datetime] = None            
     tags: Optional[List[str]] = None               
+
+class FirstMeetingIn(BaseModel):
+    meeting_date: date = Field(..., description="Solo la fecha (AAAA-MM-DD)")


### PR DESCRIPTION
… un caso

- Nuevo schema FirstMeetingIn con campo meeting_date
- Nuevo servicio AgendaCaseService con lógica de primera reunión
- Endpoint POST /agenda/cases/{case_id}/first-meeting
- Genera título y descripción automáticos a partir del caso
- Evita duplicados mediante tags (case, case:{id}, first_meeting)"